### PR TITLE
Update to v2.0.6: CMake/Qt6 build, drop legacy deps

### DIFF
--- a/net.pokerth.PokerTH.yaml
+++ b/net.pokerth.PokerTH.yaml
@@ -1,112 +1,88 @@
 app-id: net.pokerth.PokerTH
 runtime: org.kde.Platform
-runtime-version: '5.15-23.08'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
-command: pokerth
-rename-icon: pokerth
-rename-desktop-file: pokerth.desktop
-rename-appdata-file: pokerth.appdata.xml
+command: pokerth_client
 finish-args:
-  - --device=dri
-  - --share=ipc
   - --share=network
+  - --share=ipc
+  - --socket=x11
   - --socket=wayland
-  - --socket=fallback-x11
   - --socket=pulseaudio
-  - --persist=.pokerth
+  - --device=dri
+  - --filesystem=home
 cleanup:
-  - '*.a'
-  - '*.la'
   - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
 
 modules:
-  - shared-modules/SDL/sdl12-compat.json
-  - shared-modules/SDL/SDL_mixer-1.2.12.json
-
-  - name: tinyxml
-    buildsystem: autotools
-    no-autogen: true
+  - name: gsfonts
+    buildsystem: simple
     sources:
-      - type: archive
-        url: http://downloads.sourceforge.net/tinyxml/tinyxml_2_6_2.tar.gz
-        sha256: 15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593
       - type: file
-        path: tinyxml/configure.ac
-      - type: file
-        path: tinyxml/Makefile.am
-      - type: file
-        path: tinyxml/tinyxml.h.in
-      - type: shell
-        commands:
-          - autoreconf -fi
-
-  - name: protobuf
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2
-        sha256: ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
-
-  - name: gsasl
-    buildsystem: autotools
-    sources:
-    - type: archive
-      url: https://ftp.gnu.org/gnu/gsasl/gsasl-1.8.1.tar.gz
-      sha256: 4dda162a511976bfef14ad1fecd7733719dfd9c361b5d09dc8414ea9d472d8d2
-    cleanup:
-      - /bin
-      - /share/info
-
-  - name: libircclient
-    buildsystem: autotools
-    config-opts:
-      - --enable-shared
-      - --enable-ipv6
-      - --enable-openssl
-    sources:
-      - type: archive
-        url: https://downloads.sourceforge.net/libircclient/libircclient-1.10.tar.gz
-        sha256: bbb26f3af348b252c5204917a7f91cfdf172f1b6afbf4df1e561b03e20503c2d
-      - type: shell
-        commands:
-          - sed -i 's#$(DESTDIR)@libdir@#$(DESTDIR)@prefix@@libdir@#' src/Makefile.in
-      - type: script
-        dest-filename: autogen.sh
-        commands:
-          - autoreconf -vfi
+        url: http://archive.ubuntu.com/ubuntu/pool/universe/g/gsfonts/gsfonts_8.11+urwcyr1.0.7~pre44-4.4_all.deb
+        sha256: 14b9c058a7bb18c0d19d9f2735f3ad34cbc613702440bb46e8adafbeec4aabad
+    build-commands:
+      - ar x gsfonts_*.deb
+      - tar xf data.tar.* ./usr/share/fonts/type1/gsfonts/n019003l.pfb
+      - install -Dm644 usr/share/fonts/type1/gsfonts/n019003l.pfb /app/share/fonts/type1/gsfonts/n019003l.pfb
 
   - name: boost
     buildsystem: simple
-    build-commands:
-      - ./bootstrap.sh --prefix=/app --with-libraries=thread,filesystem,date_time,program_options,iostreams,regex,random,chrono
-      - ./b2 -j $FLATPAK_BUILDER_N_JOBS
-      - ./b2 install
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.bz2
-        sha256: 7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+        url: https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+        sha256: 3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4
+    build-commands:
+      - ./bootstrap.sh --prefix=/app --with-libraries=iostreams,random,thread,filesystem,program_options,system,date_time
+      - ./b2 -j$FLATPAK_BUILDER_N_JOBS install --prefix=/app
+
+  - name: protobuf
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -Dprotobuf_BUILD_TESTS=OFF
+      - -Dprotobuf_BUILD_SHARED_LIBS=ON
+      - -DABSL_PROPAGATE_CXX_STD=ON
+    sources:
+      - type: archive
+        url: https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-all-21.12.tar.gz
+        sha256: 2c6a36c7b5a55accae063667ef3c55f2642e67476d96d355ff0acb13dbb47f09
+
+  - name: websocketpp
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTS=OFF
+      - -DBUILD_EXAMPLES=OFF
+    sources:
+      - type: archive
+        url: https://github.com/zaphoyd/websocketpp/archive/refs/tags/0.8.2.tar.gz
+        sha256: 6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755
 
   - name: pokerth
-    buildsystem: qmake
-    config-opts:
-      - CONFIG+="client"
-      - DEFINES+="BOOST_BIND_GLOBAL_PLACEHOLDERS"
-      - QMAKE_CFLAGS_ISYSTEM=""
-      - QMAKE_LIBDIR+="/app/lib"
-      - pokerth.pro
-    post-install:
-      - install -Dm755 pokerth /app/bin/pokerth
-      - install -Dm644 pokerth.png /app/share/icons/hicolor/128x128/apps/pokerth.png
-      - install -Dm644 pokerth.svg /app/share/icons/hicolor/scalable/apps/pokerth.svg
-      - install -Dm644 pokerth.desktop /app/share/applications/pokerth.desktop
-      - install -Dm644 pokerth.appdata.xml /app/share/appdata/pokerth.appdata.xml
+    buildsystem: simple
     sources:
       - type: git
         url: https://github.com/pokerth/pokerth.git
-        tag: v1.1.2
-        commit: 2ca2e941a616c200e3ec81243ad0ed4243b3030e
+        tag: v2.0.6
+        commit: c9153b2d30314c102966d83268ffedc7ac5e47f3
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d.]+)$
       - type: file
         path: pokerth.appdata.xml
+    build-commands:
+      - rm -f cmake/FindBoost.cmake
+      - cmake -B _build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/app -DCMAKE_POLICY_DEFAULT_CMP0144=NEW -DBOOST_ROOT=/app
+      - cmake --build _build --target pokerth_client pokerth_lib pokerth_db pokerth_protocol zlib_compress -j$FLATPAK_BUILDER_N_JOBS
+      - cmake --install _build --component pokerth_client
+    post-install:
+      - install -Dm644 pokerth.png /app/share/icons/hicolor/256x256/apps/net.pokerth.PokerTH.png
+      - mv /app/share/applications/pokerth.desktop /app/share/applications/net.pokerth.PokerTH.desktop
+      - sed -i 's/^Exec=.*$/Exec=pokerth_client/' /app/share/applications/net.pokerth.PokerTH.desktop
+      - sed -i 's/^Icon=pokerth$/Icon=net.pokerth.PokerTH/' /app/share/applications/net.pokerth.PokerTH.desktop
+      - cp /app/share/fonts/type1/gsfonts/n019003l.pfb /app/share/pokerth/data/fonts/n019003l.pfb
+      - install -Dm644 pokerth.appdata.xml /app/share/metainfo/net.pokerth.PokerTH.metainfo.xml

--- a/net.pokerth.PokerTH.yaml
+++ b/net.pokerth.PokerTH.yaml
@@ -6,11 +6,12 @@ command: pokerth_client
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=home
+  - --filesystem=xdg-config/pokerth:create
+  - --filesystem=xdg-data/pokerth:create
 cleanup:
   - /include
   - /lib/cmake

--- a/net.pokerth.PokerTH.yaml
+++ b/net.pokerth.PokerTH.yaml
@@ -10,8 +10,6 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=xdg-config/pokerth:create
-  - --filesystem=xdg-data/pokerth:create
 cleanup:
   - /include
   - /lib/cmake

--- a/pokerth.appdata.xml
+++ b/pokerth.appdata.xml
@@ -1,31 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 PokerTH GbR <webmaster@pokerth.net> -->
 <component type="desktop-application">
- <id type="desktop">pokerth.desktop</id>
+ <id>net.pokerth.PokerTH</id>
  <metadata_license>CC-BY-3.0</metadata_license>
  <project_license>AGPL-3.0</project_license>
  <name>PokerTH</name>
  <developer_name>PokerTH GbR</developer_name>
  <summary>Poker game with single and multiplayer support</summary>
  <description>
-	<p>PokerTH is a poker game for the popular Texas Hold'em Poker variant. You can play singleplayer games with up to 9 computer-opponents or meet other PokerTH players around the world via internet games. Also multiplayer games in your LAN are possible with the network game mode. If you like to change the look and feel of the PokerTH gametable or the card deck just visit the styles gallery and choose your favourite style. To compare your poker skills with the other PokerTH players you can check your game results and rankings on our website.</p>
+  <p>PokerTH is a poker game for the popular Texas Hold'em Poker variant.
+You can play singleplayer games with up to 9 computer-opponents or meet other PokerTH players around the world via internet games. Also multiplayer games in your LAN are possible with the network game mode. If you like to change the look and feel of the PokerTH gametable or the card deck just visit the styles gallery and choose your favourite style. To compare your poker skills with the other PokerTH players you can check your game results and rankings on our website.</p>
  </description>
  <screenshots>
   <screenshot type="default">
-    <image>https://upload.wikimedia.org/wikipedia/commons/b/bd/PokerTH.png</image>
+   <image>https://upload.wikimedia.org/wikipedia/commons/b/bd/PokerTH.png</image>
   </screenshot>
  </screenshots>
  <url type="homepage">https://www.pokerth.net</url>
  <url type="bugtracker">https://github.com/pokerth/pokerth/issues</url>
  <url type="faq">https://www.pokerth.net/app.php/help/faq</url>
- <url type="donation">https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=FU66XN5FMMBNQ</url>
+ <url type="donation">https://www.paypal.com/donate?token=4FFt_mue-ebkctxTH51IY2cc5uyNLK0Kpaxbs21cYTYOqdP6rxvGBPC20qsH2q1dibc8rQ4UFHvMLzGF</url>
  <content_rating type="oars-1.1">
   <content_attribute id="social-chat">intense</content_attribute>
   <content_attribute id="money-gambling">moderate</content_attribute>
  </content_rating>
  <update_contact>webmaster@pokerth.net</update_contact>
- <launchable type="desktop-id">pokerth.desktop</launchable>
+ <launchable type="desktop-id">net.pokerth.PokerTH.desktop</launchable>
  <releases>
+  <release version="2.0.6" date="2026-03-03" type="stable">
+   <url>https://github.com/pokerth/pokerth/releases/tag/v2.0.6</url>
+  </release>
   <release version="1.1.2" date="2018-05-18" type="stable">
    <url>https://github.com/pokerth/pokerth/releases/tag/v1.1.2</url>
   </release>


### PR DESCRIPTION
- Upgrade runtime to org.kde.Platform/Sdk 6.9
- Replace qmake build system with cmake-ninja
- Source: git tag v2.0.6 (c9153b2d)
- Remove: SDL, SDL_mixer, tinyxml, gsasl, libircclient
- Add: websocketpp 0.8.2, boost 1.88.0, protobuf 21.12 (cmake)
- Add: gsfonts for bundled font
- Post-install: rename desktop/icon to net.pokerth.PokerTH.*
- Install MetaInfo to /app/share/metainfo/
- Update AppData: id=net.pokerth.PokerTH, add 2.0.6 release entry