### PR TITLE
Grant read-only access to xdg-download for theme import

### DIFF
--- a/net.pokerth.PokerTH.yaml
+++ b/net.pokerth.PokerTH.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
+  - --filesystem=xdg-download:ro
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
Fixes pokerth/pokerth#503: When importing custom game table or card deck styles via the file dialog, the Flatpak portal only grants access to the selected XML file but not to sibling image files referenced by the style.

By granting --filesystem=xdg-download:ro the app can read the entire Downloads directory, so the file dialog returns the real path and all referenced images are accessible without any code changes.