### PR TITLE
Use home:ro instead of xdg-download:ro for broader theme access

### DIFF
--- a/net.pokerth.PokerTH.yaml
+++ b/net.pokerth.PokerTH.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=xdg-download:ro
+  - --filesystem=home:ro
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
xdg-download:ro only covers ~/Downloads. With home:ro the app has read-only access to the entire home directory, so custom themes can be imported from any location without portal restrictions on sibling files.

Relates to pokerth/pokerth#503.