### PR TITLE
Update to version 2.0.7

### DIFF
--- a/net.pokerth.PokerTH.yaml
+++ b/net.pokerth.PokerTH.yaml
@@ -68,8 +68,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/pokerth/pokerth.git
-        tag: v2.0.6
-        commit: c9153b2d30314c102966d83268ffedc7ac5e47f3
+        tag: v2.0.7
+        commit: d75737498cff9fc923a855fd3df1558026dde77b
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d.]+)$

--- a/pokerth.appdata.xml
+++ b/pokerth.appdata.xml
@@ -26,8 +26,9 @@ You can play singleplayer games with up to 9 computer-opponents or meet other Po
  </content_rating>
  <update_contact>webmaster@pokerth.net</update_contact>
  <launchable type="desktop-id">net.pokerth.PokerTH.desktop</launchable>
- <releases>
-  <release version="2.0.6" date="2026-03-03" type="stable">
+ <releases>  <release version="2.0.7" date="2026-05-08" type="stable">
+   <url>https://github.com/pokerth/pokerth/releases/tag/v2.0.7</url>
+  </release>  <release version="2.0.6" date="2026-03-03" type="stable">
    <url>https://github.com/pokerth/pokerth/releases/tag/v2.0.6</url>
   </release>
   <release version="1.1.2" date="2018-05-18" type="stable">


### PR DESCRIPTION
2026-05-08 version 2.0.7:
- bugfix: ERR_NO_WINNER crash – unclaimed side-pots are now carried over instead of crashing
- bugfix: LAN games
- bugfix: empty game table name crashes client
- bugfix: player listed twice in finished ranking game
- bugfix: sql queries
- follow-up: side-pot handling
- follow-up: player list
- closing a game table window now shows a dedicated warning message
- server: AFK timeout reduced to 20 min, absent players removed faster
- server: discord webhook for lobby
- server: improved logging for disconnect debugging
- CI: automated deb, flatpak and snap builds via GitHub Actions
- macOS and Windows build fixes